### PR TITLE
Add dictionary matching test with new module

### DIFF
--- a/src/new_record_matching.py
+++ b/src/new_record_matching.py
@@ -1,0 +1,62 @@
+import json
+import os
+
+
+def load_image_list(path):
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def load_image_roles(cache_dir):
+    roles_data = {}
+    for fname in os.listdir(cache_dir):
+        if fname.endswith('.json'):
+            file_path = os.path.join(cache_dir, fname)
+            with open(file_path, encoding="utf-8") as f:
+                data = json.load(f)
+            img_path = data.get('image_path')
+            bboxes = data.get('bboxes', []) or []
+            roles = [b.get('role') for b in bboxes if b.get('role')]
+            if img_path:
+                roles_data[img_path] = roles
+    return roles_data
+
+
+def load_role_mapping(path):
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def load_records(default_records_path):
+    with open(default_records_path, encoding="utf-8") as f:
+        meta = json.load(f)
+    records = []
+    base = os.path.dirname(default_records_path)
+    for rec_file in meta.get('records', []):
+        rec_path = os.path.join(base, rec_file)
+        with open(rec_path, encoding="utf-8") as rf:
+            rec = json.load(rf)
+        records.append(rec)
+    return records
+
+
+def match_image_to_remarks(image_roles, role_mapping, records):
+    results = {}
+    for img_path, roles in image_roles.items():
+        matched = []
+        role_set = set(roles)
+        for rec in records:
+            remarks = rec.get('remarks')
+            mapping_entry = role_mapping.get(remarks, {})
+            mapping_roles = mapping_entry.get('roles', [])
+            match_type = mapping_entry.get('match', 'all')
+            if not mapping_roles:
+                continue
+            if match_type == 'all':
+                if all(r in role_set for r in mapping_roles):
+                    matched.append(remarks)
+            else:
+                if any(r in role_set for r in mapping_roles):
+                    matched.append(remarks)
+        results[img_path] = matched
+    return results

--- a/tests/test_new_dict_matching.py
+++ b/tests/test_new_dict_matching.py
@@ -1,0 +1,35 @@
+import os
+from src.new_record_matching import (
+    load_image_list,
+    load_image_roles,
+    load_role_mapping,
+    load_records,
+    match_image_to_remarks,
+)
+
+
+def test_dictionary_matching_with_real_data():
+    image_list_path = os.path.abspath("src/data/image_list20250531.json")
+    cache_dir = os.path.abspath("src/image_preview_cache")
+    role_mapping_path = os.path.abspath("src/data/role_mapping.json")
+    records_path = os.path.abspath("src/data/dictionaries/default_records.json")
+
+    image_list = load_image_list(image_list_path)
+    image_roles_all = load_image_roles(cache_dir)
+    role_mapping = load_role_mapping(role_mapping_path)
+    records = load_records(records_path)
+
+    image_roles = {p: roles for p, roles in image_roles_all.items() if p in image_list}
+    assert image_roles, "no matching image roles found"
+
+    results = match_image_to_remarks(image_roles, role_mapping, records)
+    assert isinstance(results, dict)
+    assert results, "no results"
+
+    # at least one image should have matched remarks
+    assert any(len(v) > 0 for v in results.values())
+
+    all_remarks = {rec["remarks"] for rec in records}
+    for remarks in results.values():
+        for r in remarks:
+            assert r in all_remarks


### PR DESCRIPTION
## Summary
- implement `new_record_matching` for independent matching logic
- add `test_new_dict_matching` to validate role/record matching using real data

## Testing
- `pytest tests/test_new_dict_matching.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684a23f8487c8320aca546d049acdf06